### PR TITLE
feat: #51 라면 월드컵 api 연동

### DIFF
--- a/src/constants/ramenWorldCupList.ts
+++ b/src/constants/ramenWorldCupList.ts
@@ -37,94 +37,75 @@ export const RAMEN_IMAGES: Record<RamenImageKey, string> = {
   ojingeo: ojingeoJjambbong,
 } as const;
 
-// DB의 라면 ID와 이미지 키 매핑을 위한 상수
 export const RAMEN_ID_MAP = {
-  '6728603f2f3ce8010638df5': {
+  '6728603f2f3ce80106358df5': {
     title: '신라면',
-    brand: 'Nongshim',
     imageKey: 'shin',
   },
-  '6728605a2f3ce8010638df6': {
+  '6728605a2f3ce80106358df6': {
     title: '짜파게티',
-    brand: 'Nongshim',
     imageKey: 'jjapaghetti',
   },
-  '672860692f3ce8010638df7': {
+  '672860692f3ce80106358df7': {
     title: '진라면',
-    brand: 'Ottogi',
     imageKey: 'jin',
   },
-  '672860792f3ce8010638df9': {
+  '672860792f3ce80106358df9': {
     title: '불닭볶음면',
-    brand: 'Samyang',
     imageKey: 'buldak',
   },
-  '672860972f3ce8010638dfb': {
+  '672860972f3ce80106358dfb': {
     title: '육개장',
-    brand: 'Nongshim',
     imageKey: 'yukgaejang',
   },
-  '672860a72f3ce8010638dfc': {
+  '672860a72f3ce80106358dfc': {
     title: '안성탕면',
-    brand: 'Nongshim',
     imageKey: 'ansung',
   },
-  '672860b52f3ce8010638dfd': {
+  '672860b52f3ce80106358dfd': {
     title: '너구리',
-    brand: 'Nongshim',
     imageKey: 'neoguri',
   },
-  '672860ca2f3ce8010638dfe': {
+  '672860ca2f3ce80106358dfe': {
     title: '왕뚜껑',
-    brand: 'Paldo',
     imageKey: 'wangttukkeong',
   },
-  '672860da2f3ce8010638dff': {
+  '672860da2f3ce80106358dff': {
     title: '삼양라면',
-    brand: 'Samyang',
     imageKey: 'samyang',
   },
-  '672860f02f3ce8010638e00': {
+  '672860f02f3ce80106358e00': {
     title: '팔도비빔면',
-    brand: 'Paldo',
     imageKey: 'bibim',
   },
-  '6728610a2f3ce8010638e01': {
+  '6728610a2f3ce80106358e01': {
     title: '참깨라면',
-    brand: 'Ottogi',
     imageKey: 'sesame',
   },
-  '672861232f3ce8010638e02': {
+  '672861232f3ce80106358e02': {
     title: '열라면',
-    brand: 'Ottogi',
     imageKey: 'yeol',
   },
-  '6728612f2f3ce8010638e03': {
+  '6728612f2f3ce80106358e03': {
     title: '새우탕',
-    brand: 'Nongshim',
     imageKey: 'saewootang',
   },
-  '6728613b2f3ce8010638e04': {
+  '6728613b2f3ce80106358e04': {
     title: '틈새라면',
-    brand: 'Ottogi',
     imageKey: 'teumsae',
   },
-  '672861522f3ce8010638e05': {
+  '672861522f3ce80106358e05': {
     title: '컵누들',
-    brand: 'Ottogi',
     imageKey: 'cupnoodle',
   },
-  '672861602f3ce8010638e06': {
+  '672861602f3ce80106358e06': {
     title: '오징어짬뽕',
-    brand: 'Nongshim',
     imageKey: 'ojingeo',
   },
 } as const;
 
-// 타입 정의
 export type RamenId = keyof typeof RAMEN_ID_MAP;
 
-// API 응답 타입
 export interface RamenAPIResponse {
   status: string;
   message: string;

--- a/src/hooks/useRamenQuery.ts
+++ b/src/hooks/useRamenQuery.ts
@@ -1,30 +1,26 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
-import { RamenAPIResponse, WinnerUpdateResponse } from '@/types/ramenAPI';
-import { RamenId } from '@/constants/ramenWorldCupList';
+import { axiosInstance } from '@/utils/axios';
+import { RamenAPIResponse, RamenId } from '@/constants/ramenWorldCupList';
 
 export const useRamenQuery = () => {
   const queryClient = useQueryClient();
 
-  // 라면 목록과 우승 횟수 조회
   const getRamenList = useQuery<RamenAPIResponse>({
     queryKey: ['ramenList'],
     queryFn: async () => {
-      const response = await axios.get('/events/worldcup/ramen');
-      return response.data;
+      const { data } = await axiosInstance.get('/events/worldcup/ramen');
+      return data;
     },
   });
 
-  // 우승한 라면의 카운트 업데이트
-  const updateWinnerCount = useMutation<WinnerUpdateResponse, Error, RamenId>({
-    mutationFn: async (ramenId) => {
-      const response = await axios.patch('/events/worldcup/ramen', {
+  const updateWinnerCount = useMutation({
+    mutationFn: async (ramenId: RamenId) => {
+      const { data } = await axiosInstance.patch('/events/worldcup/ramen', {
         ramen_id: ramenId,
       });
-      return response.data;
+      return data;
     },
     onSuccess: () => {
-      // 우승 횟수가 업데이트되었으므로 목록 리프레시
       queryClient.invalidateQueries({ queryKey: ['ramenList'] });
     },
   });

--- a/src/pages/RamenWorldCup/RamenWorldCupRankingPage.tsx
+++ b/src/pages/RamenWorldCup/RamenWorldCupRankingPage.tsx
@@ -56,8 +56,8 @@ const TopRankItem = styled.div<{ rank: number }>`
   ${({ rank }) =>
     rank === 1 &&
     `
-    transform: scale(1.1);  // 1등을 좀 더 크게
-    margin-top: -1rem;      // 1등을 위로 올림
+    transform: scale(1.1);
+    margin-top: -1rem;     
   `}
 `;
 
@@ -141,10 +141,9 @@ export default function RamenWorldCupRankingPage() {
       .map((item) => ({
         ...item,
         imageKey: RAMEN_ID_MAP[item._id].imageKey,
-        // 각 라면의 승률 = (해당 라면 우승 횟수 / 전체 우승 횟수) * 100
         winRate: total_count > 0 ? ((item.count / total_count) * 100).toFixed(1) : '0.0',
       }))
-      .sort((a, b) => Number(b.winRate) - Number(a.winRate));
+      .sort((a, b) => b.count - a.count);
   }, [ramenData]);
 
   const topThree = rankingData.slice(0, 3);
@@ -191,7 +190,9 @@ export default function RamenWorldCupRankingPage() {
             </RankImageContainer>
             <RankInfo>
               <RamenName>{ramen.title}</RamenName>
-              <WinRate>{ramen.winRate}%</WinRate>
+              <div>
+                <WinRate>{ramen.winRate}%</WinRate>
+              </div>
             </RankInfo>
           </RankingItem>
         ))}

--- a/src/store/ramenStore.ts
+++ b/src/store/ramenStore.ts
@@ -34,10 +34,24 @@ export const useRamenStore = create<RamenStore>((set, get) => ({
 
   initializeRamenList: (apiRamenList) => {
     // API 응답의 라면 데이터에 이미지 키를 매핑
-    const ramenList = apiRamenList.map((ramen) => ({
-      ...ramen,
-      imageKey: RAMEN_ID_MAP[ramen._id].imageKey,
-    }));
+    const ramenList = apiRamenList
+      .map((ramen) => {
+        // RAMEN_ID_MAP에서 해당 ID의 imageKey를 가져옴
+        const mappedData = RAMEN_ID_MAP[ramen._id];
+
+        if (!mappedData) {
+          console.error(`No mapping found for ramen ID: ${ramen._id}`);
+          return null;
+        }
+
+        return {
+          _id: ramen._id,
+          title: ramen.title,
+          count: ramen.count,
+          imageKey: mappedData.imageKey,
+        };
+      })
+      .filter((ramen): ramen is RamenInfo => ramen !== null); // null 값 필터링
 
     const shuffledList = [...ramenList].sort(() => Math.random() - 0.5);
 

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const axiosInstance = axios.create({
+  baseURL: 'https://hululug-server-dev.up.railway.app',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});


### PR DESCRIPTION
## 🔎 작업 내용

- 라면 월드컵 api  연동

  <br/>

## 🏞️이미지 첨부

<img width="430" alt="image" src="https://github.com/user-attachments/assets/abd4dfcc-c0a2-4275-b5eb-1af0bb66b56c">
<img width="430" alt="image" src="https://github.com/user-attachments/assets/f2a6850a-e85d-4444-83d9-80e6f467c38e">
<img width="430" alt="image" src="https://github.com/user-attachments/assets/3a11adcb-c1fd-4cd8-a92b-8da5658bb128">
<img width="430" alt="image" src="https://github.com/user-attachments/assets/f33674d2-a722-46cb-a188-d5f75819b0a9">


<br/>

## ➕ 이슈 번호 및 링크 작성

close #51 

<br/>
